### PR TITLE
Changes to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # webserv - A HTTP Web Server
 
 This is an implementation of a HTTP Web Server, in **C++98** using **C** socket libraries<br>
-and our solution for the webserv project of the 42 Core Curriculum.
+and our solution for the webserv project of the 42 Core Curriculum. The project is<br>
+the result of the colaboration between  [tblaase](https://github.com/tblaase), [TamLem](https://github.com/TamLem) and [aenglert](https://github.com/aenglert42).
 
 
 # Contents
-- [Features](https://github.com/TamLem/Webserv#features)
-- [Basics](https://github.com/TamLem/Webserv#Basics)
-- [Config File](https://github.com/TamLem/Webserv#config-file)
-- [Tester](https://github.com/TamLem/Webserv#tester)
+- [Features](#features)
+- [Basics](#basics)
+- [Config File](#config-file)
+- [How to launch](#how-to-launch)
+- [Tester](#tester)
 
 
 ## Features
@@ -54,11 +56,21 @@ Also you are able to setup multiple (virtual) servers in the same config file.<b
 This will lead the webserver to be able to run multiple configs at the same time and applying them depending on which host was called in the request.<br>
 
 
-[here](https://github.com/TamLem/Webserv/blob/master/server/config/www.conf) you can find an example config with explanations, or check [this README](https://github.com/TamLem/Webserv/blob/master/server/config/README.md), which explains our config-file in-depth.<br>
+[here](/server/config/www.conf) you can find an example config with explanations, or check [this README](/server/config/README.md), which explains our config-file in-depth.<br>
+
+## How to launch
+Compile the program via the Makefile by using ```make``` in the root directory of the repository.
+
+Use ```make run``` to run the server with the [default configuration](/server/config/test.conf) or execute the program with the path to a config-file as argument (in this case the file "test.conf" within the directory "server/config/"):
+
+```
+./webserv server/config/test.conf
+```
+For how to setup the config-file checkout the [config README](/server/config/README.md)
 
 ## Tester
-Inside the directory [ourTester](https://github.com/TamLem/Webserv/tree/master/ourTester) you are able to find our own tester that we created to test our project with.<br>
+Inside the directory [ourTester](/ourTester) you are able to find our own tester that we created to test our project with.<br>
 For some tests it uses a custom client (also written in c++ and c) and for some tests it uses curl.<br>
-For more information on how to use it check [this README](https://github.com/TamLem/Webserv/blob/master/ourTester/README.md) of the tester.<br>
+For more information on how to use it check [this README](/ourTester/README.md) of the tester.<br>
 
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Use ```make run``` to run the server with the [default configuration](/server/co
 ```
 ./webserv server/config/test.conf
 ```
-For how to setup the config-file checkout the [config README](/server/config/README.md)
+For how to setup the config-file checkout the [config README](/server/config/README.md) and the [example config with explanations](/server/config/www.conf).
 
 ## Tester
 Inside the directory [ourTester](/ourTester) you are able to find our own tester that we created to test our project with.<br>

--- a/ourTester/README.md
+++ b/ourTester/README.md
@@ -2,13 +2,13 @@
 
 You can use this tester through the makefile of our webserv project.<br>
 
-With `make tester` you can initialize the filesystem permisions for testing (it runs the [init.sh](https://github.com/TamLem/Webserv/blob/master/ourTester/init.sh)), create the tester executable `testserv`, makes and starts our webserv with corresponding config file.<br>
+With `make tester` you can initialize the filesystem permisions for testing (it runs the [init.sh](/ourTester/init.sh)), create the tester executable `testserv`, makes and starts our webserv with corresponding config file.<br>
 
 ⚠️ AFTER TESTING USE `make rmtester`, otherwise some of the filesystem can't be accessed anymore.⚠️<br>
-`make rmtester` will cleanup by reverting filesystem permission and removes tester executable `testerv` after you are done testing (it runs the [revert.sh](https://github.com/TamLem/Webserv/blob/master/ourTester/revert.sh)).<br>
+`make rmtester` will cleanup by reverting filesystem permission and removes tester executable `testerv` after you are done testing (it runs the [revert.sh](/ourTester/revert.sh)).<br>
 
 
 In the output of the tester you can see which test comes from which line of code so it is easier to find out which test resulted in what.<br>
 These tests could be extended as far as you like, since it is quite self-explanatory.<br>
 
-[back to the main README](https://github.com/TamLem/Webserv#webserv---an-http-web-server)
+[back to the main README](/README.md)

--- a/server/config/README.md
+++ b/server/config/README.md
@@ -2,18 +2,18 @@
 All key value pairs/triples have to be contained within the same line and have to be seperated by nothing else than one whitespace character, either ` ` or `\t`<br>
 
 Those are all the options:
-- [server](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#server)
-- [listen](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#listen)
-- [root](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#root)
-- [server_name](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#server_name)
-- [autoindex](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#autoindex)
-- [index_page](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#index_page)
-- [client_max_body_buffer_size](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#client_max_body_buffer_size)
-- [client_max_body_size](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#client_max_body_size)
-- [cgi](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#cgi)
-- [cgi_bin](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#cgi_bin)
-- [location](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#location)
-- [error_page](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#error_page)
+- [server](#server)
+- [listen](#listen)
+- [root](#root)
+- [server_name](#server_name)
+- [autoindex](#autoindex)
+- [index_page](#index_page)
+- [client_body_buffer_size](#client_body_buffer_size)
+- [client_max_body_size](#client_max_body_size)
+- [cgi](#cgi)
+- [cgi_bin](#cgi_bin)
+- [location](#location)
+- [error_page](#error_page)
 
 
 ## server
@@ -122,5 +122,5 @@ This enables you to setup custom error pages for all the error pages where you d
 ```
 `error_page 404 /server/data/pages/404.html`
 ```
-[back to the top](https://github.com/TamLem/Webserv/blob/master/server/config/README.md#explanations-on-how-to-use-our-config-file)<br>
-[back to the main README](https://github.com/TamLem/Webserv#webserv---an-http-web-server)
+[back to the top](#explanations-on-how-to-use-our-config-file)<br>
+[back to the main README](/README.md)


### PR DESCRIPTION
Added contributors to the intro / description of the main README. Added a "How to launch" chapter to the main README. Changed all links in all READMEs from absolute to relative to make them refer to the repository itself rather than to the "parent" repository.